### PR TITLE
Replace pointer parameters with references

### DIFF
--- a/src/FeedForwardNeuralNetwork.cc
+++ b/src/FeedForwardNeuralNetwork.cc
@@ -315,7 +315,7 @@ void FeedForwardNeuralNetwork::UpdateSlopes() {
   }
 }
 
-void FeedForwardNeuralNetwork::TrainOffline(TrainingData* training_data,
+void FeedForwardNeuralNetwork::TrainOffline(TrainingData& training_data,
                                             size_t epoch_count) {
   ResetPreviousSlopes();
   ResetWeightSteps();
@@ -327,7 +327,7 @@ void FeedForwardNeuralNetwork::TrainOffline(TrainingData* training_data,
     GetRandom().ShuffleVector(training_data);
 
     // Train the network using offline weight updates - batching.
-    for (const auto& example : *training_data) {
+    for (const auto& example : training_data) {
       // Run the network forward to get values in the output neurons.
       RunForward(example.input);
 
@@ -339,11 +339,11 @@ void FeedForwardNeuralNetwork::TrainOffline(TrainingData* training_data,
     }
 
     // Update weights.
-    UpdateWeightsOffline(i, training_data->size());
+    UpdateWeightsOffline(i, training_data.size());
   }
 }
 
-void FeedForwardNeuralNetwork::TrainOnline(TrainingData* training_data,
+void FeedForwardNeuralNetwork::TrainOnline(TrainingData& training_data,
                                            size_t epoch_count) {
   ResetWeightSteps();
 
@@ -352,7 +352,7 @@ void FeedForwardNeuralNetwork::TrainOnline(TrainingData* training_data,
     GetRandom().ShuffleVector(training_data);
 
     // Train the network using online weight updates - no batching.
-    for (const auto& example : *training_data) {
+    for (const auto& example : training_data) {
       // Run the network forward to get values in the output neurons.
       RunForward(example.input);
 
@@ -365,7 +365,7 @@ void FeedForwardNeuralNetwork::TrainOnline(TrainingData* training_data,
   }
 }
 
-void FeedForwardNeuralNetwork::Train(TrainingData* training_data,
+void FeedForwardNeuralNetwork::Train(TrainingData& training_data,
                                      size_t epoch_count) {
   switch (training_algorithm_type_) {
     case TrainingAlgorithmType::Backpropagation:

--- a/src/FeedForwardNeuralNetwork.h
+++ b/src/FeedForwardNeuralNetwork.h
@@ -225,7 +225,7 @@ class FeedForwardNeuralNetwork : public Perceptron {
    * @see TrainingAlgorithmType
    * @see TrainingData
    */
-  void Train(TrainingData* training_data, size_t epoch_count);
+  void Train(TrainingData& training_data, size_t epoch_count);
 
  protected:
   void UpdateSlopes();
@@ -241,8 +241,8 @@ class FeedForwardNeuralNetwork : public Perceptron {
   void ResetSlopes();
   void ResetPreviousSlopes();
 
-  void TrainOffline(TrainingData* training_data, size_t epoch_count);
-  void TrainOnline(TrainingData* training_data, size_t epoch_count);
+  void TrainOffline(TrainingData& training_data, size_t epoch_count);
+  void TrainOnline(TrainingData& training_data, size_t epoch_count);
 
  private:
   static constexpr double DefaultLearningRate = 0.7;

--- a/src/Perceptron.cc
+++ b/src/Perceptron.cc
@@ -295,11 +295,11 @@ void Perceptron::SetWeights(const std::vector<double>& weights) {
   weights_.assign(weights.cbegin(), weights.cend());
 }
 
-void Perceptron::GetOutput(std::vector<double>* output) const {
-  output->resize(GetOutputNeuronCount());
+void Perceptron::GetOutput(std::vector<double>& output) const {
+  output.resize(GetOutputNeuronCount());
   for (size_t i = 0; i < GetOutputNeuronCount(); i++) {
     const auto& neuron = GetOutputNeuron(i);
-    output->at(i) = neuron.value;
+    output[i] = neuron.value;
   }
 }
 

--- a/src/Perceptron.h
+++ b/src/Perceptron.h
@@ -133,7 +133,7 @@ class Perceptron : public MultiLayerNeuralTopology {
    * Writes all of the output neuron values into |output|.<br/>
    * Existing values in |output| will be discarded.
    */
-  void GetOutput(std::vector<double>* output) const;
+  void GetOutput(std::vector<double>& output) const;
 
   /**
    * Build the neural network.<br/>

--- a/src/RandomWrapper.h
+++ b/src/RandomWrapper.h
@@ -61,8 +61,8 @@ class RandomWrapper {
    * Shuffle the elements of |vec| into random positions.
    */
   template <typename T>
-  void ShuffleVector(std::vector<T>* vec) {
-    std::shuffle(vec->begin(), vec->end(), Engine());
+  void ShuffleVector(std::vector<T>& vec) {
+    std::shuffle(vec.begin(), vec.end(), Engine());
   }
 
  protected:

--- a/src/TrainingData.cc
+++ b/src/TrainingData.cc
@@ -14,44 +14,44 @@
 
 namespace {
 
-void SimpleScale(std::vector<double>* vec, double old_min, double factor,
+void SimpleScale(std::vector<double>& vec, double old_min, double factor,
                  double new_min) {
-  for (auto& val : *vec) {
+  for (auto& val : vec) {
     val = (val - old_min) * factor + new_min;
   }
 }
 
-void SimpleDescale(std::vector<double>* vec, double old_min, double factor,
+void SimpleDescale(std::vector<double>& vec, double old_min, double factor,
                    double new_min) {
-  for (auto& val : *vec) {
+  for (auto& val : vec) {
     val = (val - new_min) / factor + old_min;
   }
 }
 
-void StdevScale(std::vector<double>* vec, double mean, double stdev,
+void StdevScale(std::vector<double>& vec, double mean, double stdev,
                 double multiplier) {
-  for (auto& val : *vec) {
+  for (auto& val : vec) {
     val = (val - mean) / (stdev * multiplier);
   }
 }
 
-void StdevDescale(std::vector<double>* vec, double mean, double stdev,
+void StdevDescale(std::vector<double>& vec, double mean, double stdev,
                   double multiplier) {
-  for (auto& val : *vec) {
+  for (auto& val : vec) {
     val = (val * stdev * multiplier) + mean;
   }
 }
 
-void UniformNormScale(std::vector<double>* vec, double mean,
+void UniformNormScale(std::vector<double>& vec, double mean,
                       double uniform_norm, double multiplier) {
-  for (auto& val : *vec) {
+  for (auto& val : vec) {
     val = (val - mean) / (uniform_norm * multiplier);
   }
 }
 
-void UniformNormDescale(std::vector<double>* vec, double mean,
+void UniformNormDescale(std::vector<double>& vec, double mean,
                         double uniform_norm, double multiplier) {
-  for (auto& val : *vec) {
+  for (auto& val : vec) {
     val = (val * uniform_norm * multiplier) + mean;
   }
 }
@@ -193,9 +193,9 @@ void TrainingData::ScaleSimple() {
   CalculateMinMax();
 
   for (auto& example : *this) {
-    SimpleScale(&example.input, input_old_min_, input_factor_,
+    SimpleScale(example.input, input_old_min_, input_factor_,
                 simple_scaling_new_min_);
-    SimpleScale(&example.output, output_old_min_, output_factor_,
+    SimpleScale(example.output, output_old_min_, output_factor_,
                 simple_scaling_new_min_);
   }
 }
@@ -205,9 +205,9 @@ void TrainingData::ScaleStandardDeviation() {
   CalculateStdev();
 
   for (auto& example : *this) {
-    StdevScale(&example.input, input_mean_, input_standard_deviation_,
+    StdevScale(example.input, input_mean_, input_standard_deviation_,
                standard_deviation_multiplier_);
-    StdevScale(&example.output, output_mean_, output_standard_deviation_,
+    StdevScale(example.output, output_mean_, output_standard_deviation_,
                standard_deviation_multiplier_);
   }
 }
@@ -217,36 +217,36 @@ void TrainingData::ScaleUniformNorm() {
   CalculateUniformNorm();
 
   for (auto& example : *this) {
-    UniformNormScale(&example.input, input_mean_, input_uniform_norm_,
+    UniformNormScale(example.input, input_mean_, input_uniform_norm_,
                      uniform_norm_multiplier_);
-    UniformNormScale(&example.output, output_mean_, output_uniform_norm_,
+    UniformNormScale(example.output, output_mean_, output_uniform_norm_,
                      uniform_norm_multiplier_);
   }
 }
 
 void TrainingData::DescaleSimple() {
   for (auto& example : *this) {
-    SimpleDescale(&example.input, input_old_min_, input_factor_,
+    SimpleDescale(example.input, input_old_min_, input_factor_,
                   simple_scaling_new_min_);
-    SimpleDescale(&example.output, output_old_min_, output_factor_,
+    SimpleDescale(example.output, output_old_min_, output_factor_,
                   simple_scaling_new_min_);
   }
 }
 
 void TrainingData::DescaleStandardDeviation() {
   for (auto& example : *this) {
-    StdevDescale(&example.input, input_mean_, input_standard_deviation_,
+    StdevDescale(example.input, input_mean_, input_standard_deviation_,
                  standard_deviation_multiplier_);
-    StdevDescale(&example.output, output_mean_, output_standard_deviation_,
+    StdevDescale(example.output, output_mean_, output_standard_deviation_,
                  standard_deviation_multiplier_);
   }
 }
 
 void TrainingData::DescaleUniformNorm() {
   for (auto& example : *this) {
-    UniformNormDescale(&example.input, input_mean_, input_uniform_norm_,
+    UniformNormDescale(example.input, input_mean_, input_uniform_norm_,
                        uniform_norm_multiplier_);
-    UniformNormDescale(&example.output, output_mean_, output_uniform_norm_,
+    UniformNormDescale(example.output, output_mean_, output_uniform_norm_,
                        uniform_norm_multiplier_);
   }
 }
@@ -281,7 +281,7 @@ void TrainingData::Descale() {
   }
 }
 
-void TrainingData::ScaleInput(std::vector<double>* vec) const {
+void TrainingData::ScaleInput(std::vector<double>& vec) const {
   switch (scaling_algorithm_) {
     case ScalingAlgorithm::None:
       return;
@@ -299,7 +299,7 @@ void TrainingData::ScaleInput(std::vector<double>* vec) const {
   }
 }
 
-void TrainingData::ScaleOutput(std::vector<double>* vec) const {
+void TrainingData::ScaleOutput(std::vector<double>& vec) const {
   switch (scaling_algorithm_) {
     case ScalingAlgorithm::None:
       return;
@@ -317,7 +317,7 @@ void TrainingData::ScaleOutput(std::vector<double>* vec) const {
   }
 }
 
-void TrainingData::DescaleInput(std::vector<double>* vec) const {
+void TrainingData::DescaleInput(std::vector<double>& vec) const {
   switch (scaling_algorithm_) {
     case ScalingAlgorithm::None:
       return;
@@ -335,7 +335,7 @@ void TrainingData::DescaleInput(std::vector<double>* vec) const {
   }
 }
 
-void TrainingData::DescaleOutput(std::vector<double>* vec) const {
+void TrainingData::DescaleOutput(std::vector<double>& vec) const {
   switch (scaling_algorithm_) {
     case ScalingAlgorithm::None:
       return;

--- a/src/TrainingData.h
+++ b/src/TrainingData.h
@@ -135,28 +135,28 @@ class TrainingData : public std::vector<Example> {
    * Uses the scaling parameters calculated during a previous call to Scale.
    * @see Scale
    */
-  void ScaleInput(std::vector<double>* vec) const;
+  void ScaleInput(std::vector<double>& vec) const;
 
   /**
    * Scale one vector of output.<br/>
    * Uses the scaling parameters calculated during a previous call to Scale.
    * @see Scale
    */
-  void ScaleOutput(std::vector<double>* vec) const;
+  void ScaleOutput(std::vector<double>& vec) const;
 
   /**
    * Descale one vector of input.<br/>
    * Uses the scaling parameters calculated during a previous call to Scale.
    * @see Scale
    */
-  void DescaleInput(std::vector<double>* vec) const;
+  void DescaleInput(std::vector<double>& vec) const;
 
   /**
    * Descale one vector of output.<br/>
    * Uses the scaling parameters calculated during a previous call to Scale.
    * @see Scale
    */
-  void DescaleOutput(std::vector<double>* vec) const;
+  void DescaleOutput(std::vector<double>& vec) const;
 
   /**
    * Convert sequential data into examples.<br/>

--- a/test/test.cc
+++ b/test/test.cc
@@ -22,7 +22,7 @@ using panann::TrainingData;
 
 namespace testing {
 
-const char* TrainingAlgorithmNames[] = {
+const std::string TrainingAlgorithmNames[] = {
     "Backpropagation", "BatchingBackpropagation", "QuickBackpropagation",
     "ResilientBackpropagation", "SimulatedAnnealingResilientBackpropagation"};
 
@@ -290,19 +290,19 @@ const PerceptronTestCase feedForwardTestCases[] = {
           5,  13, 6,  14, 18, 21, 26, 31, 36, 7,  15,
       }}}};
 
-void MakeXorTwoBitTrainingData(TrainingData* training_data) {
-  training_data->resize(4);
-  training_data->at(0).input = {0.0, 0.0};
-  training_data->at(0).output = {0.0};
-  training_data->at(1).input = {1.0, 1.0};
-  training_data->at(1).output = {0.0};
-  training_data->at(2).input = {1.0, 0.0};
-  training_data->at(2).output = {1.0};
-  training_data->at(3).input = {0.0, 1.0};
-  training_data->at(3).output = {1.0};
+void MakeXorTwoBitTrainingData(TrainingData& training_data) {
+  training_data.resize(4);
+  training_data[0].input = {0.0, 0.0};
+  training_data[0].output = {0.0};
+  training_data[1].input = {1.0, 1.0};
+  training_data[1].output = {0.0};
+  training_data[2].input = {1.0, 0.0};
+  training_data[2].output = {1.0};
+  training_data[3].input = {0.0, 1.0};
+  training_data[3].output = {1.0};
 }
 
-void MakeSineTrainingData(TrainingData* training_data, size_t steps) {
+void MakeSineTrainingData(TrainingData& training_data, size_t steps) {
   const size_t sine_sample_count = steps * 2;
   const double step_size = 1.0 / sine_sample_count;
   constexpr double pi = 3.14159265358979323846;
@@ -313,34 +313,34 @@ void MakeSineTrainingData(TrainingData* training_data, size_t steps) {
     sine_data[i] = std::sin(step_size * i * 2 * pi);
   }
 
-  training_data->FromSequentialData(sine_data, steps);
+  training_data.FromSequentialData(sine_data, steps);
 }
 
-void MakeTestNetwork(FeedForwardNeuralNetwork* nn,
-                     TrainingData* training_data) {
+void MakeTestNetwork(FeedForwardNeuralNetwork& nn,
+                     TrainingData& training_data) {
   constexpr size_t neurons_per_hidden_layer = 5;
 
-  nn->DisableShortcutConnections();
-  nn->SetInputNeuronCount(training_data->at(0).input.size());
-  nn->SetOutputNeuronCount(training_data->at(0).output.size());
-  nn->AddHiddenLayer(neurons_per_hidden_layer);
-  nn->AddHiddenLayer(neurons_per_hidden_layer);
-  nn->Construct();
+  nn.DisableShortcutConnections();
+  nn.SetInputNeuronCount(training_data[0].input.size());
+  nn.SetOutputNeuronCount(training_data[0].output.size());
+  nn.AddHiddenLayer(neurons_per_hidden_layer);
+  nn.AddHiddenLayer(neurons_per_hidden_layer);
+  nn.Construct();
 }
 
-void MakeTestNetwork(RecurrentNeuralNetwork* rnn, TrainingData* training_data) {
+void MakeTestNetwork(RecurrentNeuralNetwork& rnn, TrainingData& training_data) {
   constexpr size_t cells_per_layer = 5;
   constexpr size_t cell_memory_size = 3;
 
-  rnn->SetInputNeuronCount(training_data->at(0).input.size());
-  rnn->SetOutputNeuronCount(training_data->at(0).output.size());
-  rnn->SetCellMemorySize(cell_memory_size);
-  rnn->AddHiddenLayer(cells_per_layer, {});
-  rnn->AddHiddenLayer(cells_per_layer, {});
-  rnn->Construct();
+  rnn.SetInputNeuronCount(training_data[0].input.size());
+  rnn.SetOutputNeuronCount(training_data[0].output.size());
+  rnn.SetCellMemorySize(cell_memory_size);
+  rnn.AddHiddenLayer(cells_per_layer, {});
+  rnn.AddHiddenLayer(cells_per_layer, {});
+  rnn.Construct();
 }
 
-void Compare(size_t left, size_t right, const char* msg) {
+void Compare(size_t left, size_t right, const std::string& msg) {
   if (left != right) {
     std::cout << "Fail! Expected: " << left << " Found: " << right << ". "
               << msg << std::endl;
@@ -402,52 +402,52 @@ void ComparePerceptron(const TestPerceptron& test_perceptron,
   }
 }
 
-void MakeTestNetwork(FeedForwardNeuralNetwork* nn,
+void MakeTestNetwork(FeedForwardNeuralNetwork& nn,
                      const PerceptronTestCase& test) {
   if (test.enable_shortcuts) {
-    nn->EnableShortcutConnections();
+    nn.EnableShortcutConnections();
   }
-  nn->SetInputNeuronCount(test.input_neurons);
-  nn->SetOutputNeuronCount(test.output_neurons);
+  nn.SetInputNeuronCount(test.input_neurons);
+  nn.SetOutputNeuronCount(test.output_neurons);
   for (const auto& layer : test.perceptron.layers) {
-    nn->AddHiddenLayer(layer.neuron_count);
+    nn.AddHiddenLayer(layer.neuron_count);
   }
-  nn->Construct();
+  nn.Construct();
 }
 
 void TestConstruct(const PerceptronTestCase& test) {
   FeedForwardNeuralNetwork nn;
-  MakeTestNetwork(&nn, test);
+  MakeTestNetwork(nn, test);
   ComparePerceptron(test.perceptron, nn);
 }
 
 void TrainAndTestNetwork(
-    FeedForwardNeuralNetwork* nn, TrainingData* training_data,
+    FeedForwardNeuralNetwork& nn, TrainingData& training_data,
     FeedForwardNeuralNetwork::TrainingAlgorithmType algorithm, size_t epochs) {
   std::cout << "Testing feed-forward neural network training with "
             << TrainingAlgorithmNames[static_cast<int>(algorithm)] << "..."
             << std::endl;
-  nn->SetTrainingAlgorithmType(algorithm);
+  nn.SetTrainingAlgorithmType(algorithm);
 
   std::cout << "\tInitializing weight values to random (-1, 1)..." << std::endl;
-  nn->InitializeWeightsRandom();
-  std::cout << "\t\tError before training: " << nn->GetError(*training_data)
+  nn.InitializeWeightsRandom();
+  std::cout << "\t\tError before training: " << nn.GetError(training_data)
             << std::endl;
-  nn->Train(training_data, epochs);
+  nn.Train(training_data, epochs);
   std::cout << "\t\tError after training for " << epochs
-            << " epochs: " << nn->GetError(*training_data) << std::endl;
+            << " epochs: " << nn.GetError(training_data) << std::endl;
 
   std::cout << "\tInitializing weight values via Widrow-Nguyen..." << std::endl;
-  nn->InitializeWeights(*training_data);
-  std::cout << "\t\tError before training: " << nn->GetError(*training_data)
+  nn.InitializeWeights(training_data);
+  std::cout << "\t\tError before training: " << nn.GetError(training_data)
             << std::endl;
-  nn->Train(training_data, epochs);
+  nn.Train(training_data, epochs);
   std::cout << "\t\tError after training for " << epochs
-            << " epochs: " << nn->GetError(*training_data) << std::endl
+            << " epochs: " << nn.GetError(training_data) << std::endl
             << std::endl;
 }
 
-void TrainAndTest(FeedForwardNeuralNetwork* nn, TrainingData* training_data,
+void TrainAndTest(FeedForwardNeuralNetwork& nn, TrainingData& training_data,
                   size_t epochs) {
   TrainAndTestNetwork(
       nn, training_data,
@@ -470,24 +470,24 @@ void TrainAndTest(FeedForwardNeuralNetwork* nn, TrainingData* training_data,
                       epochs);
 }
 
-void TestNetwork(RecurrentNeuralNetwork* rnn, TrainingData* training_data,
+void TestNetwork(RecurrentNeuralNetwork& rnn, TrainingData& training_data,
                  size_t run_steps) {
   std::cout << "Testing recurrent neural network..." << std::endl;
 
   std::cout << "\tInitializing weight values to random (-1, 1)..." << std::endl;
-  rnn->InitializeWeightsRandom();
+  rnn.InitializeWeightsRandom();
 
-  std::cout << "\t\tError before running: " << rnn->GetError(*training_data)
+  std::cout << "\t\tError before running: " << rnn.GetError(training_data)
             << std::endl;
 
   for (size_t i = 0; i < run_steps; i++) {
     // Just run the network forward on each example input.
-    for (const auto& example : *training_data) {
-      rnn->RunForward(example.input);
+    for (const auto& example : training_data) {
+      rnn.RunForward(example.input);
     }
 
     std::cout << "\t\tError after run #" << i + 1 << ": "
-              << rnn->GetError(*training_data) << std::endl;
+              << rnn.GetError(training_data) << std::endl;
   }
 
   std::cout << std::endl;
@@ -496,18 +496,18 @@ void TestNetwork(RecurrentNeuralNetwork* rnn, TrainingData* training_data,
 int DoTests() {
   TrainingData training_data;
 
-  MakeXorTwoBitTrainingData(&training_data);
+  MakeXorTwoBitTrainingData(training_data);
   FeedForwardNeuralNetwork nn;
-  MakeTestNetwork(&nn, &training_data);
+  MakeTestNetwork(nn, training_data);
   constexpr size_t test_epochs = 1000;
-  TrainAndTest(&nn, &training_data, test_epochs);
+  TrainAndTest(nn, training_data, test_epochs);
 
   constexpr size_t sine_data_steps = 200;
-  MakeSineTrainingData(&training_data, sine_data_steps);
+  MakeSineTrainingData(training_data, sine_data_steps);
   RecurrentNeuralNetwork rnn;
-  MakeTestNetwork(&rnn, &training_data);
+  MakeTestNetwork(rnn, training_data);
   constexpr size_t rnn_run_steps = 5;
-  TestNetwork(&rnn, &training_data, rnn_run_steps);
+  TestNetwork(rnn, training_data, rnn_run_steps);
 
   for (const auto& test : feedForwardTestCases) {
     TestConstruct(test);


### PR DESCRIPTION
Just removes most raw pointer usage by replacing method parameters taking pointer types with reference types.